### PR TITLE
drivers: fix section mismatches

### DIFF
--- a/drivers/irqchip/irq-gic-v3-its.c
+++ b/drivers/irqchip/irq-gic-v3-its.c
@@ -1530,7 +1530,7 @@ static struct of_device_id its_device_id[] = {
 	{},
 };
 
-int its_init(struct device_node *node, struct rdists *rdists,
+int __init its_init(struct device_node *node, struct rdists *rdists,
 	     struct irq_domain *parent_domain)
 {
 	struct device_node *np;

--- a/drivers/thermal/msm_thermal.c
+++ b/drivers/thermal/msm_thermal.c
@@ -1454,7 +1454,7 @@ static int get_kernel_cluster_info(int *cluster_id, cpumask_t *cluster_cpus)
 	return cluster_cnt;
 }
 
-static void update_cpu_topology(struct device *dev)
+static void __init update_cpu_topology(struct device *dev)
 {
 	int cluster_id[NR_CPUS] = {[0 ... NR_CPUS-1] = -1};
 	cpumask_t cluster_cpus[NR_CPUS];

--- a/include/linux/irqchip/arm-gic-v3.h
+++ b/include/linux/irqchip/arm-gic-v3.h
@@ -355,7 +355,7 @@ static inline void gic_write_eoir(u64 irq)
 
 struct irq_domain;
 int its_cpu_init(void);
-int its_init(struct device_node *node, struct rdists *rdists,
+int __init its_init(struct device_node *node, struct rdists *rdists,
 	     struct irq_domain *domain);
 
 #endif


### PR DESCRIPTION
This commit should fix the following section mismatches:
WARNING: drivers/built-in.o(.text+0x345c): Section mismatch in reference from the function its_init() to the function .init.text:its_alloc_lpi_tables.isra.0()
The function its_init() references
the function __init its_alloc_lpi_tables.isra.0().
This is often because its_init lacks a __init 
annotation or the annotation of its_alloc_lpi_tables.isra.0 is wrong.

WARNING: drivers/built-in.o(.text+0x509438): Section mismatch in reference from the function update_cpu_topology() to the function .init.text:get_sync_cluster()
The function update_cpu_topology() references
the function __init get_sync_cluster().
This is often because update_cpu_topology lacks a __init 
annotation or the annotation of get_sync_cluster is wrong.

  LINK    vmlinux
  LD      vmlinux.o
  MODPOST vmlinux.o
WARNING: vmlinux.o(.text+0x33041c): Section mismatch in reference from the function its_init() to the function .init.text:its_alloc_lpi_tables.isra.0()
The function its_init() references
the function __init its_alloc_lpi_tables.isra.0().
This is often because its_init lacks a __init 
annotation or the annotation of its_alloc_lpi_tables.isra.0 is wrong.

WARNING: vmlinux.o(.text+0x8363f8): Section mismatch in reference from the function update_cpu_topology() to the function .init.text:get_sync_cluster()
The function update_cpu_topology() references
the function __init get_sync_cluster().
This is often because update_cpu_topology lacks a __init 
annotation or the annotation of get_sync_cluster is wrong.

To build the kernel despite the mismatches, build with:
'make CONFIG_NO_ERROR_ON_MISMATCH=y'
(NOTE: This is not recommended)